### PR TITLE
`list_tabs.py` rework

### DIFF
--- a/examples/contributed/README.md
+++ b/examples/contributed/README.md
@@ -1,0 +1,4 @@
+User Contributed Examples
+=
+
+This folder contains user submitted code which may contain different, modified or alternative examples of Geckordp.

--- a/examples/contributed/list_tabs.py
+++ b/examples/contributed/list_tabs.py
@@ -1,0 +1,136 @@
+""" This basic example demonstrates how to list all tabs.
+"""
+import json
+from subprocess import Popen
+
+from geckordp.rdp_client import RDPClient
+from geckordp.actors.root import RootActor
+from geckordp.profile import (
+    ProfileManager,
+    FirefoxProfile,
+)
+from geckordp.firefox import Firefox
+from geckordp.settings import (
+    GECKORDP,
+    log,
+)
+# NOTE: enable debug logging by default
+GECKORDP.DEBUG = 1
+GECKORDP.DEBUG_REQUEST = 1
+GECKORDP.DEBUG_RESPONSE = 1
+
+
+def main(
+    profile_name: str,
+    host: str = 'localhost',
+    port: int = 6000,
+
+    # NOTE: optionally clone any existing profile before mutate.
+    clone_existing_profile: bool = True,
+    restore_from_last_session: bool = True,
+    always_spawn_browser: bool = True,
+
+) -> None:
+
+    # clone default profile to 'geckordp'
+    pm = ProfileManager()
+    profile: FirefoxProfile = pm.get_profile_by_name(profile_name)
+
+    # make a new profile if none exists by given name
+    if profile is None:
+        profile: FirefoxProfile = pm.create(profile_name)
+
+    # Clone from the target profile instead of mutating it?
+    # In the case where the cloned profile already exists (by
+    # having a `.geckordp` suffix in the name) load that
+    # (previously cloned) profile for mutation B)
+    elif clone_existing_profile:
+
+        clone_name: str = f'{profile_name}.geckordp'
+        profile: FirefoxProfile = pm.get_profile_by_name(clone_name)
+
+        # only clone if no clone already exists
+        if not profile:
+            profile: FirefoxProfile = pm.clone(
+                profile_name,
+                clone_name,
+            )
+
+    # apply low-level setts to enable RDP ctl over TCP
+    # (among many other things!)
+    profile.set_required_configs()
+
+    # load the last tab set state from any prior session?
+    if restore_from_last_session:
+        # https://kb.mozillazine.org/Browser.startup.page#3
+        profile.set_config('browser.startup.page', 3)
+        profile.set_config('browser.sessionstore.resume_from_crash', True)
+        profile.set_config("browser.sessionstore.restore_on_demand", True)
+        profile.set_config("browser.sessionstore.restore_tabs_lazily", True)
+        profile.set_config("toolkit.startup.max_resumed_crashes", 1)
+
+    # create client and connect to firefox
+    # NOTE: by default this starts a few bg worker threads!
+    client = RDPClient(
+        timeout_sec=0.5,
+        executor_workers=1,
+    )
+    resp: dict | None = client.connect(host, port)
+    if (
+        resp is None
+    ):
+        if always_spawn_browser:
+            # NOTE: if no firefox process can be contacted at the (host,
+            # port) socket address, start firefox with specified profile
+            # and RDP addr.
+            proc: Popen = Firefox.start(
+                "https://example.com/",
+                port,
+                profile.name,
+                # append_args=["-headless"],
+            )
+            log(f'Firefox started with pid={proc.pid}')
+            resp: dict | None = client.connect(
+                host,
+                port,
+                # timeout_sec=120,
+            )
+            if resp is None:
+                raise RuntimeError(
+                    f'Could not connect to firefox instance localhost@{port}!?'
+                )
+        else:
+            raise RuntimeError(
+                f'No browser listening on RDP socket @ {(host, port)}!?'
+            )
+
+    log(f'Connected to browser @ {(host, port)} -> {resp}')
+
+    # initialize root
+    root = RootActor(client)
+
+    # get a list of tabs
+    tabs: list[dict] = root.list_tabs()
+    json_tabs: str = json.dumps(tabs, indent=2)
+    print(
+        f'TABS ARE:\n'
+        f'{json_tabs}'
+    )
+
+    # NOTE: We block here due to bg threads that were spawned in the RDPClient?
+    # TODO: probably be more explicit about the concurrency here
+    # since it's a bit confusing what is actually going on ;)
+    # uncomment for debug/introspection if needed
+    # import pdbp; pdbp.set_trace()
+
+
+if __name__ == "__main__":
+    # Use a project-relevant profile name if user does NOT pass
+    # one as the first CLI argument.
+    profile_name: str = 'geckordp'
+
+    from sys import argv
+    if len(argv) > 1:
+        profile_name: str = str(argv[1])
+
+    main(profile_name)

--- a/examples/list_tabs.py
+++ b/examples/list_tabs.py
@@ -1,136 +1,46 @@
 """ This basic example demonstrates how to list all tabs.
 """
-import json
-from subprocess import Popen
 
+import json
 from geckordp.rdp_client import RDPClient
 from geckordp.actors.root import RootActor
-from geckordp.profile import (
-    ProfileManager,
-    FirefoxProfile,
-)
+from geckordp.profile import ProfileManager
 from geckordp.firefox import Firefox
-from geckordp.settings import (
-    GECKORDP,
-    log,
-)
-# NOTE: enable debug logging by default
-GECKORDP.DEBUG = 1
-GECKORDP.DEBUG_REQUEST = 1
-GECKORDP.DEBUG_RESPONSE = 1
 
 
-def main(
-    profile_name: str,
-    host: str = 'localhost',
-    port: int = 6000,
+""" Uncomment to enable debug output
+"""
+# from geckordp.settings import GECKORDP
+# GECKORDP.DEBUG = 1
+# GECKORDP.DEBUG_REQUEST = 1
+# GECKORDP.DEBUG_RESPONSE = 1
 
-    # NOTE: optionally clone any existing profile before mutate.
-    clone_existing_profile: bool = True,
-    restore_from_last_session: bool = True,
-    always_spawn_browser: bool = True,
 
-) -> None:
-
+def main():
     # clone default profile to 'geckordp'
     pm = ProfileManager()
-    profile: FirefoxProfile = pm.get_profile_by_name(profile_name)
-
-    # make a new profile if none exists by given name
-    if profile is None:
-        profile: FirefoxProfile = pm.create(profile_name)
-
-    # Clone from the target profile instead of mutating it?
-    # In the case where the cloned profile already exists (by
-    # having a `.geckordp` suffix in the name) load that
-    # (previously cloned) profile for mutation B)
-    elif clone_existing_profile:
-
-        clone_name: str = f'{profile_name}.geckordp'
-        profile: FirefoxProfile = pm.get_profile_by_name(clone_name)
-
-        # only clone if no clone already exists
-        if not profile:
-            profile: FirefoxProfile = pm.clone(
-                profile_name,
-                clone_name,
-            )
-
-    # apply low-level setts to enable RDP ctl over TCP
-    # (among many other things!)
+    profile_name = "geckordp"
+    port = 6000
+    pm.clone("default-release", profile_name)
+    profile = pm.get_profile_by_name(profile_name)
     profile.set_required_configs()
 
-    # load the last tab set state from any prior session?
-    if restore_from_last_session:
-        # https://kb.mozillazine.org/Browser.startup.page#3
-        profile.set_config('browser.startup.page', 3)
-        profile.set_config('browser.sessionstore.resume_from_crash', True)
-        profile.set_config("browser.sessionstore.restore_on_demand", True)
-        profile.set_config("browser.sessionstore.restore_tabs_lazily", True)
-        profile.set_config("toolkit.startup.max_resumed_crashes", 1)
+    # start firefox with specified profile
+    Firefox.start("https://example.com/", port, profile_name, ["-headless"])
 
     # create client and connect to firefox
-    # NOTE: by default this starts a few bg worker threads!
-    client = RDPClient(
-        timeout_sec=0.5,
-        executor_workers=1,
-    )
-    resp: dict | None = client.connect(host, port)
-    if (
-        resp is None
-    ):
-        if always_spawn_browser:
-            # NOTE: if no firefox process can be contacted at the (host,
-            # port) socket address, start firefox with specified profile
-            # and RDP addr.
-            proc: Popen = Firefox.start(
-                port,
-                profile.name,
-                # url="https://example.com/",
-                # append_args=["-headless"],
-            )
-            log(f'Firefox started with pid={proc.pid}')
-            resp: dict | None = client.connect(
-                host,
-                port,
-                # timeout_sec=120,
-            )
-            if resp is None:
-                raise RuntimeError(
-                    f'Could not connect to firefox instance localhost@{port}!?'
-                )
-        else:
-            raise RuntimeError(
-                f'No browser listening on RDP socket @ {(host, port)}!?'
-            )
-
-    log(f'Connected to browser @ {(host, port)} -> {resp}')
+    client = RDPClient()
+    client.connect("localhost", port)
 
     # initialize root
     root = RootActor(client)
 
     # get a list of tabs
-    tabs: list[dict] = root.list_tabs()
-    json_tabs: str = json.dumps(tabs, indent=2)
-    print(
-        f'TABS ARE:\n'
-        f'{json_tabs}'
-    )
+    tabs = root.list_tabs()
+    print(json.dumps(tabs, indent=2))
 
-    # NOTE: We block here due to bg threads that were spawned in the RDPClient?
-    # TODO: probably be more explicit about the concurrency here
-    # since it's a bit confusing what is actually going on ;)
-    # uncomment for debug/introspection if needed
-    # import pdbp; pdbp.set_trace()
+    input()
 
 
 if __name__ == "__main__":
-    # Use a project-relevant profile name if user does NOT pass
-    # one as the first CLI argument.
-    profile_name: str = 'geckordp'
-
-    from sys import argv
-    if len(argv) > 1:
-        profile_name: str = str(argv[1])
-
-    main(profile_name)
+    main()

--- a/examples/list_tabs.py
+++ b/examples/list_tabs.py
@@ -1,48 +1,136 @@
 """ This basic example demonstrates how to list all tabs.
 """
 import json
+from subprocess import Popen
+
 from geckordp.rdp_client import RDPClient
 from geckordp.actors.root import RootActor
-from geckordp.profile import ProfileManager
+from geckordp.profile import (
+    ProfileManager,
+    FirefoxProfile,
+)
 from geckordp.firefox import Firefox
+from geckordp.settings import (
+    GECKORDP,
+    log,
+)
+# NOTE: enable debug logging by default
+GECKORDP.DEBUG = 1
+GECKORDP.DEBUG_REQUEST = 1
+GECKORDP.DEBUG_RESPONSE = 1
 
 
-""" Uncomment to enable debug output
-"""
-#from geckordp.settings import GECKORDP
-#GECKORDP.DEBUG = 1
-#GECKORDP.DEBUG_REQUEST = 1
-#GECKORDP.DEBUG_RESPONSE = 1
+def main(
+    profile_name: str,
+    host: str = 'localhost',
+    port: int = 6000,
 
+    # NOTE: optionally clone any existing profile before mutate.
+    clone_existing_profile: bool = True,
+    restore_from_last_session: bool = True,
+    always_spawn_browser: bool = True,
 
-def main():
+) -> None:
+
     # clone default profile to 'geckordp'
     pm = ProfileManager()
-    profile_name = "geckordp"
-    port = 6000
-    pm.clone("default-release", profile_name)
-    profile = pm.get_profile_by_name(profile_name)
+    profile: FirefoxProfile = pm.get_profile_by_name(profile_name)
+
+    # make a new profile if none exists by given name
+    if profile is None:
+        profile: FirefoxProfile = pm.create(profile_name)
+
+    # Clone from the target profile instead of mutating it?
+    # In the case where the cloned profile already exists (by
+    # having a `.geckordp` suffix in the name) load that
+    # (previously cloned) profile for mutation B)
+    elif clone_existing_profile:
+
+        clone_name: str = f'{profile_name}.geckordp'
+        profile: FirefoxProfile = pm.get_profile_by_name(clone_name)
+
+        # only clone if no clone already exists
+        if not profile:
+            profile: FirefoxProfile = pm.clone(
+                profile_name,
+                clone_name,
+            )
+
+    # apply low-level setts to enable RDP ctl over TCP
+    # (among many other things!)
     profile.set_required_configs()
 
-    # start firefox with specified profile
-    Firefox.start("https://example.com/",
-                  port,
-                  profile_name,
-                  ["-headless"])
+    # load the last tab set state from any prior session?
+    if restore_from_last_session:
+        # https://kb.mozillazine.org/Browser.startup.page#3
+        profile.set_config('browser.startup.page', 3)
+        profile.set_config('browser.sessionstore.resume_from_crash', True)
+        profile.set_config("browser.sessionstore.restore_on_demand", True)
+        profile.set_config("browser.sessionstore.restore_tabs_lazily", True)
+        profile.set_config("toolkit.startup.max_resumed_crashes", 1)
 
     # create client and connect to firefox
-    client = RDPClient()
-    client.connect("localhost", port)
+    # NOTE: by default this starts a few bg worker threads!
+    client = RDPClient(
+        timeout_sec=0.5,
+        executor_workers=1,
+    )
+    resp: dict | None = client.connect(host, port)
+    if (
+        resp is None
+    ):
+        if always_spawn_browser:
+            # NOTE: if no firefox process can be contacted at the (host,
+            # port) socket address, start firefox with specified profile
+            # and RDP addr.
+            proc: Popen = Firefox.start(
+                port,
+                profile.name,
+                # url="https://example.com/",
+                # append_args=["-headless"],
+            )
+            log(f'Firefox started with pid={proc.pid}')
+            resp: dict | None = client.connect(
+                host,
+                port,
+                # timeout_sec=120,
+            )
+            if resp is None:
+                raise RuntimeError(
+                    f'Could not connect to firefox instance localhost@{port}!?'
+                )
+        else:
+            raise RuntimeError(
+                f'No browser listening on RDP socket @ {(host, port)}!?'
+            )
+
+    log(f'Connected to browser @ {(host, port)} -> {resp}')
 
     # initialize root
     root = RootActor(client)
 
     # get a list of tabs
-    tabs = root.list_tabs()
-    print(json.dumps(tabs, indent=2))
+    tabs: list[dict] = root.list_tabs()
+    json_tabs: str = json.dumps(tabs, indent=2)
+    print(
+        f'TABS ARE:\n'
+        f'{json_tabs}'
+    )
 
-    input()
+    # NOTE: We block here due to bg threads that were spawned in the RDPClient?
+    # TODO: probably be more explicit about the concurrency here
+    # since it's a bit confusing what is actually going on ;)
+    # uncomment for debug/introspection if needed
+    # import pdbp; pdbp.set_trace()
 
 
 if __name__ == "__main__":
-    main()
+    # Use a project-relevant profile name if user does NOT pass
+    # one as the first CLI argument.
+    profile_name: str = 'geckordp'
+
+    from sys import argv
+    if len(argv) > 1:
+        profile_name: str = str(argv[1])
+
+    main(profile_name)

--- a/geckordp/actors/web_socket.py
+++ b/geckordp/actors/web_socket.py
@@ -2,6 +2,7 @@ from geckordp.actors.actor import Actor
 
 
 class WebSocketActor(Actor):
+    # NOTE: this link is borked :(
     """ https://github.com/mozilla/gecko-dev/blob/master/devtools/shared/specs/websocket.js
     """
 

--- a/geckordp/firefox.py
+++ b/geckordp/firefox.py
@@ -32,7 +32,7 @@ class Firefox():
         Returns:
             Path: The path of firefox profiles.
         """
-        paths: list[Path] = []
+        paths: List[Path] = []
         if "linux" in platform:
             paths = [
                 Path.home().joinpath(".mozilla/firefox/"),
@@ -95,31 +95,25 @@ class Firefox():
             raise RuntimeError(f"The platform '{platform}' is not supported")
 
     @staticmethod
-    def start(
-        port: int,
-        profile: str,
-        url: str | None = None,
-        append_args: List[str] | None = None,
-        override_firefox_path: str = "",
-        auto_kill: bool = True,
-        wait: bool = True,
-    ) -> subprocess.Popen:
+    def start(url: str,
+              port: int,
+              profile: str,
+              append_args: List[str] | None = None,
+              override_firefox_path="",
+              auto_kill=True,
+              wait=True) -> subprocess.Popen:
         """ Starts a firefox instance.
 
-        .. note::
-            The profile needs to be once configured with
-            :func:`~geckordp.profile.FirefoxProfile.set_required_configs`.
-            To manually start firefox, this command can be
-            used:
+            .. note::
+                The profile needs to be once configured with :func:`~geckordp.profile.FirefoxProfile.set_required_configs`.
+                To manually start firefox, this command can be used:
 
-            **firefox -new-instance -no-remote -new-window \
-                https://example.com/ -p geckordp \
-                --start-debugger-server 6000**
+                **firefox -new-instance -no-remote -new-window https://example.com/ -p geckordp --start-debugger-server 6000**
 
         Args:
+            url (str): The url for the start page
             port (int): The port to use for the rdp server.
             profile (str): The profile to use.
-            url (str): Optional url for the start page
             append_args (List[str], optional): Additional args for Firefox. Defaults to None.
             override_firefox_path (str, optional): Overrides the default firefox binary path.
             auto_kill (bool, optional): Enables the termination of firefox if the python process is also terminated.
@@ -131,19 +125,14 @@ class Firefox():
         if (override_firefox_path == ""):
             override_firefox_path = Firefox.get_binary_path()
 
-        args = [
-            override_firefox_path,
-            "-new-instance",
-            "-no-remote",
-            "-no-default-browser-check",
-            "-p", profile,
-            "--start-debugger-server", str(port),
-            "-new-window",
-        ]
-        # NOTE: don't open a first page unless explicitly passed by
-        # caller.
-        if url:
-            args.append(url)
+        args = [override_firefox_path,
+                "-new-instance",
+                "-no-remote",
+                "-no-default-browser-check",
+                "-new-window", url,
+                "-p", profile,
+                "--start-debugger-server", str(port)
+                ]
 
         if (append_args is not None):
             for arg in append_args:

--- a/geckordp/firefox.py
+++ b/geckordp/firefox.py
@@ -32,7 +32,7 @@ class Firefox():
         Returns:
             Path: The path of firefox profiles.
         """
-        paths = []
+        paths: list[Path] = []
         if "linux" in platform:
             paths = [
                 Path.home().joinpath(".mozilla/firefox/"),
@@ -95,25 +95,31 @@ class Firefox():
             raise RuntimeError(f"The platform '{platform}' is not supported")
 
     @staticmethod
-    def start(url: str,
-              port: int,
-              profile: str,
-              append_args: List[str] | None = None,
-              override_firefox_path="",
-              auto_kill=True,
-              wait=True) -> subprocess.Popen:
+    def start(
+        port: int,
+        profile: str,
+        url: str | None = None,
+        append_args: List[str] | None = None,
+        override_firefox_path: str = "",
+        auto_kill: bool = True,
+        wait: bool = True,
+    ) -> subprocess.Popen:
         """ Starts a firefox instance.
 
-            .. note:: 
-                The profile needs to be once configured with :func:`~geckordp.profile.FirefoxProfile.set_required_configs`.
-                To manually start firefox, this command can be used:
+        .. note::
+            The profile needs to be once configured with
+            :func:`~geckordp.profile.FirefoxProfile.set_required_configs`.
+            To manually start firefox, this command can be
+            used:
 
-                **firefox -new-instance -no-remote -new-window https://example.com/ -p geckordp --start-debugger-server 6000**
+            **firefox -new-instance -no-remote -new-window \
+                https://example.com/ -p geckordp \
+                --start-debugger-server 6000**
 
         Args:
-            url (str): The url for the start page
             port (int): The port to use for the rdp server.
             profile (str): The profile to use.
+            url (str): Optional url for the start page
             append_args (List[str], optional): Additional args for Firefox. Defaults to None.
             override_firefox_path (str, optional): Overrides the default firefox binary path.
             auto_kill (bool, optional): Enables the termination of firefox if the python process is also terminated.
@@ -125,14 +131,19 @@ class Firefox():
         if (override_firefox_path == ""):
             override_firefox_path = Firefox.get_binary_path()
 
-        args = [override_firefox_path,
-                "-new-instance",
-                "-no-remote",
-                "-no-default-browser-check",
-                "-new-window", url,
-                "-p", profile,
-                "--start-debugger-server", str(port)
-                ]
+        args = [
+            override_firefox_path,
+            "-new-instance",
+            "-no-remote",
+            "-no-default-browser-check",
+            "-p", profile,
+            "--start-debugger-server", str(port),
+            "-new-window",
+        ]
+        # NOTE: don't open a first page unless explicitly passed by
+        # caller.
+        if url:
+            args.append(url)
 
         if (append_args is not None):
             for arg in append_args:


### PR DESCRIPTION
As per discussion in #9 this is an initial attempt at making the example more useful out of the box (for eg. without silent errors on missing / bad input profile names).

---
### Notes worth discussing:
- [ ] I changed a couple internal methods on `RDPClient.connect()` and `Firefox.start()` to improve the ability to get the business logic I wanted for browser instance connecting as demonstrated in the example script.
- [ ] I've changed a bit of formatting in a couple places (including adding some minor type annotations that were missing) mostly to do with making function signatures *multi-line* style for readability ( I honestly couldn't read any of the func signatures, IMO they're pretty crammed).
  - not sure if this is something you're adamantly opposed to but, i don't really enjoy reading the internals due to the current style of many bits including spots that are definitely not pep8 adherent. I'd be much more apt to hack on internals if we can get to a bit easier to read style and possibly increase the line len limit as well as drop some of the verbosity in doc strings (which don't seem to be necessary given you're using type annotations AFAICT 😉 )
- [ ] for the `list_tabs` example I've add a variety of optional settings and connection logic changes that we should go over if you don't approve 😂 

