### PR TITLE
Allow requests to be sent async from the caller's perspective, resulting in much faster processing

### DIFF
--- a/geckordp/actors/web_console.py
+++ b/geckordp/actors/web_console.py
@@ -70,6 +70,7 @@ class WebConsoleActor(Actor):
         selected_object_actor="",
         inner_window_id=-1,
         mapped: dict | None = None,
+        force_async=False,
     ):
         args = {
             "to": self.actor_id,
@@ -87,7 +88,7 @@ class WebConsoleActor(Actor):
             args["innerWindowID"] = inner_window_id
         if mapped is not None:
             args["mapped"] = mapped
-        return self.client.send_receive(args)
+        return self.client.send_receive(args, force_async=force_async)
 
     def autocomplete(
         self,


### PR DESCRIPTION
This PR adds a `force_async` flag to `send_receive` to make it work asynchronously from the caller's perspective, e.g. if they themselves want to use await/async syntax and are running their own event loop outside of RDPClient.

This works by using [`asyncio.run_coroutine_threadsafe`](https://docs.python.org/3/library/asyncio-task.html#asyncio.run_coroutine_threadsafe) to submit send requests from other threads to RDPClient's own internal event loop. Then there are other changes to make this work more efficiently, including adding a queue for outstanding requests.

I have tested this PR using code that iterates through cookies, given at the end of the PR - change the `FORCE_ASYNC_TEST` constant to switch the test on or off. The performance increase is >20x, 0.35 seconds with this PR vs 8 seconds without:

With this PR:
~~~~
$ time python extract-cookies.py  > cookies.txt ; wc -l cookies.txt
cookies expected:  349

real	0m0.357s
user	0m0.124s
sys	0m0.022s
349 cookies.txt
~~~~

Without this PR:
~~~~
$ time python extract-cookies.py  > cookies.txt ; wc -l cookies.txt
cookies expected:  349

real	0m8.009s
user	0m0.156s
sys	0m0.098s
349 cookies.txt
~~~~

Happy to change the appearance of the API, for example there could perhaps be a better name for `force_async`.

----

## Test code

```python
import asyncio
import concurrent.futures
import json
import sys

from geckordp.actors.descriptors.process import ProcessActor
from geckordp.actors.events import Events
from geckordp.actors.root import RootActor
from geckordp.actors.web_console import WebConsoleActor
from geckordp.rdp_client import RDPClient

""" Uncomment to enable debug output
"""
# from geckordp.settings import GECKORDP
# GECKORDP.DEBUG = 1
# GECKORDP.DEBUG_EVENTS = 1
# GECKORDP.DEBUG_REQUEST = 1
# GECKORDP.DEBUG_RESPONSE = 1

FORCE_ASYNC_TEST = True

async def evaluate_js(client, console, cid, msgs):
    loop = asyncio.get_running_loop()
    msgs = list(msgs)
    resf = [loop.create_future() for _ in msgs]
    resp = resf[:]
    cfut = []
    def on_evaluation_result(data: dict):
        #print(json.dumps(data, indent=2))
        if data["type"] == "longString":
            raise ValueError("output too long!")
        # event handlers are run in other threads
        loop.call_soon_threadsafe(lambda *args: resp.pop().set_result(data["result"]))
    try:
        client.add_event_listener(cid, Events.WebConsole.EVALUATION_RESULT, on_evaluation_result)
        for m in msgs:
            if FORCE_ASYNC_TEST:
                cfut.append(console.evaluate_js_async(m, force_async=True))
            else:
                console.evaluate_js_async(m)

        res = asyncio.as_completed(resf, timeout=client.timeout_sec)

        if FORCE_ASYNC_TEST:
            cfu = concurrent.futures.as_completed(cfut, timeout=client.timeout_sec)
            # for proper error-handling we must iterate cfu[i] before res[i]
            # e.g. in case a send failed, we don't want to grab the next result
            return [await w for (_, w) in zip(cfu, res)]
        else:
            return [await w for w in res]
    finally:
        client.remove_event_listener(cid, Events.WebConsole.EVALUATION_RESULT, on_evaluation_result)

async def main():
    # create client and connect to firefox
    client = RDPClient()
    client.connect("localhost", 9222)
    try:
        # initialize root
        root = RootActor(client)

        # get a single tab from tabs and retrieve its actor ID
        procs = root.list_processes()
        for proc_descriptor in procs:
            if not proc_descriptor.get("isParent", False):
                continue

            proc = ProcessActor(client, proc_descriptor["actor"])
            actor_ids = proc.get_target()
            #print("proc", proc_descriptor, file=sys.stderr)
            #print("proc target", actor_ids, file=sys.stderr)
            cid = actor_ids["consoleActor"]

            # initialize console and start listening
            console = WebConsoleActor(client, cid)
            console.start_listeners([])

            [n] = await evaluate_js(client, console, cid, ["Services.cookies.cookies.length"])
            print("cookies expected: ", n, file=sys.stderr)
            msgs = [r"""
{
  let c = Services.cookies.cookies[%s];
  `${c.rawHost}	${c.isDomain}	${c.path}	${c.isSecure}	${c.expires}	${c.name}	${c.value}`;
}
""" % i for i in range(n)]
            for c in await evaluate_js(client, console, cid, msgs):
                print(c)
    finally:
        client.disconnect()

if __name__ == "__main__":
    asyncio.run(main())
```